### PR TITLE
Laravel 11 support

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -6,12 +6,11 @@ jobs:
   test:
     runs-on: ubuntu-latest
 
-    # we want to run it on supported combination of Laravel and PHP versions
     strategy:
       fail-fast: false
       matrix:
-        php: ['8.1', '8.2']
-        laravel: ['^9.0', '^10.0']
+        php: [ '8.2', '8.3' ]
+        laravel: [ '^11.0' ]
 
     steps:
       - name: Checkout the repo

--- a/composer.json
+++ b/composer.json
@@ -20,12 +20,12 @@
         }
     ],
     "require": {
-        "php": "^8.1 || ^8.2",
+        "php": "^8.2",
         "ext-json": "*",
-        "laravel/framework": "^9.0 || ^10.0"
+        "laravel/framework": "^11.0"
     },
     "require-dev": {
-        "orchestra/testbench": "^7.0 || ^8.0",
+        "orchestra/testbench": "^9.0",
         "tmarsteel/mockery-callable-mock": "~2.1",
         "netsells/code-standards-laravel": "^1.1"
     },

--- a/tests/Integration/OptimalNumberOfQueriesTest.php
+++ b/tests/Integration/OptimalNumberOfQueriesTest.php
@@ -23,7 +23,7 @@ class OptimalNumberOfQueriesTest extends TestCase
     /**
      * @dataProvider resourceProvider
      */
-    public function testCreatesAsManyQueriesAsEagerLoadingResourceCollection(string $basicClass, string $superClass)
+    public function test_creates_as_many_queries_as_eager_loading_resource_collection(string $basicClass, string $superClass)
     {
         $this->fullLibraryFactory()->create();
 
@@ -55,7 +55,7 @@ class OptimalNumberOfQueriesTest extends TestCase
     /**
      * @dataProvider resourceProvider
      */
-    public function testCreatesAsManyQueriesAsLazyEagerLoadingResourceCollection(string $basicClass, string $superClass)
+    public function test_creates_as_many_queries_as_lazy_eager_loading_resource_collection(string $basicClass, string $superClass)
     {
         $this->fullLibraryFactory()->create();
 
@@ -81,7 +81,7 @@ class OptimalNumberOfQueriesTest extends TestCase
     /**
      * @dataProvider resourceProvider
      */
-    public function testCreatesAsManyQueriesAsEagerLoadingResource(string $basicClass, string $superClass)
+    public function test_creates_as_many_queries_as_eager_loading_resource(string $basicClass, string $superClass)
     {
         $this->fullLibraryFactory()->create();
 
@@ -113,7 +113,7 @@ class OptimalNumberOfQueriesTest extends TestCase
     /**
      * @dataProvider resourceProvider
      */
-    public function testCreatesAsManyQueriesAsLazyEagerLoadingResource(string $basicClass, string $superClass)
+    public function test_creates_as_many_queries_as_lazy_eager_loading_resource(string $basicClass, string $superClass)
     {
         $this->fullLibraryFactory()->create();
 

--- a/tests/Integration/PreloadModeTest.php
+++ b/tests/Integration/PreloadModeTest.php
@@ -8,7 +8,7 @@ use Netsells\Http\Resources\Tests\Integration\Resources\PreloadMode\BookWithSing
 
 class PreloadModeTest extends TestCase
 {
-    public function testPreloadLoadsSingleRelationOnResource()
+    public function test_preload_loads_single_relation_on_resource()
     {
         /** @var Book $book */
         $book = Book::factory()->forAuthor()->create()->fresh();
@@ -18,7 +18,7 @@ class PreloadModeTest extends TestCase
         $this->assertTrue($book->relationLoaded('author'));
     }
 
-    public function testPreloadLoadsMultipleRelationsOnResource()
+    public function test_preload_loads_multiple_relations_on_resource()
     {
         /** @var Book $book */
         $book = Book::factory()->forAuthor()->create()->fresh();
@@ -29,7 +29,7 @@ class PreloadModeTest extends TestCase
         $this->assertTrue($book->relationLoaded('genres'));
     }
 
-    public function testPreloadLoadsSingleRelationOnResourceCollection()
+    public function test_preload_loads_single_relation_on_resource_collection()
     {
         /** @var Book[] $books */
         $books = Book::factory()->count(3)->forAuthor()->create()->fresh();
@@ -41,7 +41,7 @@ class PreloadModeTest extends TestCase
         }
     }
 
-    public function testPreloadLoadsMultipleRelationsOnResourceCollection()
+    public function test_preload_loads_multiple_relations_on_resource_collection()
     {
         /** @var Book[] $books */
         $books = Book::factory()->count(3)->forAuthor()->create()->fresh();

--- a/tests/Integration/ResourceTestCase.php
+++ b/tests/Integration/ResourceTestCase.php
@@ -16,7 +16,7 @@ abstract class ResourceTestCase extends TestCase
     /**
      * @dataProvider resourceProvider
      */
-    public function testSuperReducesQueriesOverBasicResourceAndBothMatch(string $basicClass, string $superClass)
+    public function test_super_reduces_queries_over_basic_resource_and_both_match(string $basicClass, string $superClass)
     {
         /** @var Model $model */
         $model = $this->produce(1)->fresh();
@@ -35,7 +35,7 @@ abstract class ResourceTestCase extends TestCase
     /**
      * @dataProvider resourceProvider
      */
-    public function testSuperReducesQueriesOverBasicResourceCollectionAndBothMatch(string $basicClass, string $superClass)
+    public function test_super_reduces_queries_over_basic_resource_collection_and_both_match(string $basicClass, string $superClass)
     {
         /** @var Collection $models */
         $models = $this->produce($this->collectionSize)->fresh();

--- a/tests/Integration/UseModeTest.php
+++ b/tests/Integration/UseModeTest.php
@@ -11,7 +11,7 @@ use Netsells\Http\Resources\Tests\Integration\Resources\UseMode\BookWithSingleRe
 
 class UseModeTest extends TestCase
 {
-    public function testUseLoadsAndProvidesSingleRelation()
+    public function test_use_loads_and_provides_single_relation()
     {
         /** @var Book $book */
         $book = Book::factory()->forAuthor()->create()->fresh();
@@ -25,7 +25,7 @@ class UseModeTest extends TestCase
             ->response();
     }
 
-    public function testUseLoadsAndProvidesMultipleRelations()
+    public function test_use_loads_and_provides_multiple_relations()
     {
         /** @var Book $book */
         $book = Book::factory()->forAuthor()->create()->fresh();
@@ -40,7 +40,7 @@ class UseModeTest extends TestCase
             ->response();
     }
 
-    public function testUseSkipsMissingValue()
+    public function test_use_skips_missing_value()
     {
         /** @var Book $book */
         $book = Book::factory()->forAuthor()->create()->fresh();


### PR DESCRIPTION
This will be released as a new major version (v2.0) which only supports Laravel 11. This is due to Laravel 9 and 10 no longer being maintained and Laravel 11 requiring a minimum PHP version of 8.2.